### PR TITLE
Add beta and nightly rust to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
 language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+matrix:
+  allow_failure:
+    - rust: nightly
+
 sudo: required
 
 before_install:
@@ -23,3 +31,8 @@ before_install:
   - cd toxcore && autoreconf -if && ./configure && make && sudo make install
   - echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
   - sudo ldconfig
+  - sudo add-apt-repository --yes ppa:hansjorg/rust
+  - sudo add-apt-repository --yes ppa:cmrx64/cargo
+  - sudo apt-get update -qq
+install:
+  - sudo apt-get install -qq rust-nightly cargo


### PR DESCRIPTION
This PR also should allow to add support for automatic project rebuilds when new nightly builds of Rust will be out, just needs to be added to http://www.rust-ci.org/p/add/
