### PR TITLE
remove needless unstable lib

### DIFF
--- a/src/av/mod.rs
+++ b/src/av/mod.rs
@@ -3,7 +3,7 @@ use libc::{c_int, c_uint, c_void};
 use std::sync::Arc;
 use std::cell::{RefCell, UnsafeCell};
 use std::error::Error;
-use std::{fmt, raw, slice, mem};
+use std::{fmt, slice, mem};
 use std::thread::{sleep_ms};
 use core::{Tox};
 


### PR DESCRIPTION
```
Compiling rstox v0.0.1 (https://github.com/suhr/rstox.git#d4919112)                                                                                  
/home/quininer/.cargo/git/checkouts/rstox-d7ad266d38212a37/master/src/av/mod.rs:6:16: 6:19 error: use of unstable library feature 'raw' (see issue #27751)                                                                                                                                                      
/home/quininer/.cargo/git/checkouts/rstox-d7ad266d38212a37/master/src/av/mod.rs:6 use std::{fmt, raw, slice, mem};                                      
                                                                                                 ^~~                                                    
/home/quininer/.cargo/git/checkouts/rstox-d7ad266d38212a37/master/src/av/mod.rs:6:16: 6:19 help: add #![feature(raw)] to the crate attributes to enable 
error: aborting due to previous error                                                                                                                   
Could not compile `rstox`. 
```
